### PR TITLE
Add list-jdks and list-vendors commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         runner: [ubuntu-latest, macos-latest, windows-latest]
     name: test-${{ matrix.runner }}

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,18 @@ SPDX-License-Identifier: MIT
 
 # Python API
 
+## Querying the JDK index
+
+```{eval-rst}
+.. autofunction:: cjdk.list_vendors
+.. versionadded:: 0.4.0
+```
+
+```{eval-rst}
+.. autofunction:: cjdk.list_jdks
+.. versionadded:: 0.4.0
+```
+
 ## Working with cached JDKs
 
 ```{eval-rst}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,15 @@ See also the section on [versioning](versioning-scheme).
 
 ## [Unreleased]
 
-- No notable changes yet.
+### Added
+
+- Python API functions `list_jdks()` and `list_vendors()`.
+- Command line commands `ls` and `ls-vendors`.
+- Light postprocessing of vendor names, notably `ibm-semeru-openj9`.
+
+### Changed
+
+- Command line command `cache-jdk` renamed to `cache`.
 
 ## [0.3.0] - 2022-07-09
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,26 @@ More details about the choices and defaults for [`VENDOR`](./vendors.md),
 [`VERSION`](./versions.md), and [`--cache_dir`](./cachedir.md) are available on
 separate pages.
 
+## Querying the JDK index
+
+### `ls`
+
+```{command-output} cjdk ls --help
+```
+
+```{eval-rst}
+.. versionadded:: 0.4.0
+```
+
+### `ls-vendors`
+
+```{command-output} cjdk ls-vendors --help
+```
+
+```{eval-rst}
+.. versionadded:: 0.4.0
+```
+
 ## Working with cached JDKs
 
 ### `exec`
@@ -53,13 +73,13 @@ $ cjdk --jdk temurin-jre:17.0.3 java-home
 (The output will depend on your operating system and configuration; the example
 shown was on macOS.)
 
-### `cache-jdk`
+### `cache`
 
-```{command-output} cjdk cache-jdk --help
+```{command-output} cjdk cache --help
 ```
 
 ```{eval-rst}
-.. versionadded:: 0.2.0
+.. versionadded:: 0.4.0
 ```
 
 ## Caching arbitrary files and packages

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,7 +79,8 @@ shown was on macOS.)
 ```
 
 ```{eval-rst}
-.. versionadded:: 0.4.0
+.. versionchanged:: 0.4.0
+   Renamed from ``cache-jdk``.
 ```
 
 ## Caching arbitrary files and packages

--- a/src/cjdk/__init__.py
+++ b/src/cjdk/__init__.py
@@ -2,11 +2,12 @@
 # Copyright 2022 Board of Regents of the University of Wisconsin System
 # SPDX-License-Identifier: MIT
 
-from ._api import cache_file, cache_jdk, cache_package, java_env, java_home, list_jdks
+from ._api import cache_file, cache_jdk, cache_package, java_env, java_home, list_jdks, list_vendors
 from ._version import __version__ as __version__
 
 __all__ = [
     "cache_file",
+    "list_vendors",
     "list_jdks",
     "cache_jdk",
     "cache_package",

--- a/src/cjdk/__init__.py
+++ b/src/cjdk/__init__.py
@@ -2,7 +2,15 @@
 # Copyright 2022 Board of Regents of the University of Wisconsin System
 # SPDX-License-Identifier: MIT
 
-from ._api import cache_file, cache_jdk, cache_package, java_env, java_home, list_jdks, list_vendors
+from ._api import (
+    cache_file,
+    cache_jdk,
+    cache_package,
+    java_env,
+    java_home,
+    list_jdks,
+    list_vendors,
+)
 from ._version import __version__ as __version__
 
 __all__ = [

--- a/src/cjdk/__init__.py
+++ b/src/cjdk/__init__.py
@@ -15,10 +15,10 @@ from ._version import __version__ as __version__
 
 __all__ = [
     "cache_file",
-    "list_vendors",
-    "list_jdks",
     "cache_jdk",
     "cache_package",
     "java_env",
     "java_home",
+    "list_jdks",
+    "list_vendors",
 ]

--- a/src/cjdk/__init__.py
+++ b/src/cjdk/__init__.py
@@ -2,11 +2,12 @@
 # Copyright 2022 Board of Regents of the University of Wisconsin System
 # SPDX-License-Identifier: MIT
 
-from ._api import cache_file, cache_jdk, cache_package, java_env, java_home
+from ._api import cache_file, cache_jdk, cache_package, java_env, java_home, list_jdks
 from ._version import __version__ as __version__
 
 __all__ = [
     "cache_file",
+    "list_jdks",
     "cache_jdk",
     "cache_package",
     "java_env",

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -73,15 +73,20 @@ def ls_vendors(ctx):
     _api.list_vendors(**ctx.obj)
 
 
-@click.command(short_help="List available JDKs matching criteria.")
+@click.command(short_help="List cached or available JDKs matching criteria.")
 @click.pass_context
-def ls(ctx):
+@click.option(
+    "--cached/--available",
+    default=True,
+    help="Show only already-cached JDKs, or show all available JDKs from the index (default cached only).",
+)
+def ls(ctx, cached: bool = False):
     """
     Output a list of JDKs matching the given criteria.
 
     See 'cjdk --help' for the common options used to specify the JDK.
     """
-    _api.list_jdks(**ctx.obj)
+    _api.list_jdks(**ctx.obj, cached_only=cached)
 
 
 @click.command(short_help="Ensure the requested JDK is cached.")

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -68,9 +68,11 @@ def main(ctx, jdk, cache_dir, index_url, index_ttl, os, arch, progress):
 @click.pass_context
 def ls_vendors(ctx):
     """
-    Output the list of available vendors.
+    Print the list of available JDK vendors.
     """
-    _api.list_vendors(**ctx.obj)
+    vendors = _api.list_vendors(**ctx.obj)
+    if vendors:
+        print("\n".join(vendors))
 
 
 @click.command(short_help="List cached or available JDKs matching criteria.")
@@ -82,11 +84,13 @@ def ls_vendors(ctx):
 )
 def ls(ctx, cached: bool = False):
     """
-    Output a list of JDKs matching the given criteria.
+    Print the list of JDKs matching the given criteria.
 
-    See 'cjdk --help' for the common options used to specify the JDK.
+    See 'cjdk --help' for the common options used to specify the criteria.
     """
-    _api.list_jdks(**ctx.obj, cached_only=cached)
+    jdks = _api.list_jdks(**ctx.obj, cached_only=cached)
+    if jdks:
+        print("\n".join(jdks))
 
 
 @click.command(short_help="Ensure the requested JDK is cached.")

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -64,6 +64,15 @@ def main(ctx, jdk, cache_dir, index_url, index_ttl, os, arch, progress):
     )
 
 
+@click.command(short_help="List available JDK vendors.")
+@click.pass_context
+def list_vendors(ctx):
+    """
+    Output the list of available vendors.
+    """
+    _api.list_vendors(**ctx.obj)
+
+
 @click.command(short_help="List available JDKs matching criteria.")
 @click.pass_context
 def list_jdks(ctx):
@@ -234,6 +243,7 @@ def cache_package(ctx, url, name, sha1, sha256, sha512):
 
 main.add_command(java_home)
 main.add_command(exec)
+main.add_command(list_vendors)
 main.add_command(list_jdks)
 main.add_command(cache_jdk)
 main.add_command(cache_file)

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -64,6 +64,17 @@ def main(ctx, jdk, cache_dir, index_url, index_ttl, os, arch, progress):
     )
 
 
+@click.command(short_help="List available JDKs matching criteria.")
+@click.pass_context
+def list_jdks(ctx):
+    """
+    Output a list of JDKs matching the given criteria.
+
+    See 'cjdk --help' for the common options used to specify the JDK.
+    """
+    _api.list_jdks(**ctx.obj)
+
+
 @click.command(short_help="Ensure the requested JDK is cached.")
 @click.pass_context
 def cache_jdk(ctx):
@@ -223,6 +234,7 @@ def cache_package(ctx, url, name, sha1, sha256, sha512):
 
 main.add_command(java_home)
 main.add_command(exec)
+main.add_command(list_jdks)
 main.add_command(cache_jdk)
 main.add_command(cache_file)
 main.add_command(cache_package)

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -66,7 +66,7 @@ def main(ctx, jdk, cache_dir, index_url, index_ttl, os, arch, progress):
 
 @click.command(short_help="List available JDK vendors.")
 @click.pass_context
-def list_vendors(ctx):
+def ls_vendors(ctx):
     """
     Output the list of available vendors.
     """
@@ -75,7 +75,7 @@ def list_vendors(ctx):
 
 @click.command(short_help="List available JDKs matching criteria.")
 @click.pass_context
-def list_jdks(ctx):
+def ls(ctx):
     """
     Output a list of JDKs matching the given criteria.
 
@@ -243,8 +243,8 @@ def cache_package(ctx, url, name, sha1, sha256, sha512):
 
 main.add_command(java_home)
 main.add_command(exec)
-main.add_command(list_vendors)
-main.add_command(list_jdks)
+main.add_command(ls_vendors)
+main.add_command(ls)
 main.add_command(cache_jdk)
 main.add_command(cache_file)
 main.add_command(cache_package)

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -71,7 +71,7 @@ def cache_jdk(ctx):
     Download and extract the requested JDK if it is not already cached.
 
     Usually there is no need to invoke this command on its own, but it may be
-    useful if you want any potentil JDK download to happen at a controlled
+    useful if you want any potential JDK download to happen at a controlled
     point in time.
 
     See 'cjdk --help' for the common options used to specify the JDK and how it
@@ -108,7 +108,7 @@ def exec(ctx, prog, args):
     """
     Run PROG with the environment variables set for the requested JDK.
 
-    The JDK is download if not already cached.
+    The JDK is downloaded if not already cached.
 
     See 'cjdk --help' for the common options used to specify the JDK and how it
     is obtained.

--- a/src/cjdk/__main__.py
+++ b/src/cjdk/__main__.py
@@ -86,7 +86,7 @@ def ls(ctx):
 
 @click.command(short_help="Ensure the requested JDK is cached.")
 @click.pass_context
-def cache_jdk(ctx):
+def cache(ctx):
     """
     Download and extract the requested JDK if it is not already cached.
 
@@ -96,6 +96,15 @@ def cache_jdk(ctx):
 
     See 'cjdk --help' for the common options used to specify the JDK and how it
     is obtained.
+    """
+    _api.cache_jdk(**ctx.obj)
+
+
+@click.command(hidden=True)
+@click.pass_context
+def cache_jdk(ctx):
+    """
+    Deprecated. Use cache function instead.
     """
     _api.cache_jdk(**ctx.obj)
 
@@ -241,14 +250,17 @@ def cache_package(ctx, url, name, sha1, sha256, sha512):
     )
 
 
+# Register current commands.
 main.add_command(java_home)
 main.add_command(exec)
 main.add_command(ls_vendors)
 main.add_command(ls)
-main.add_command(cache_jdk)
+main.add_command(cache)
 main.add_command(cache_file)
 main.add_command(cache_package)
 
+# Register hidden/deprecated commands, for backwards compatibility.
+main.add_command(cache_jdk)
 
 if __name__ == "__main__":
     main()

--- a/src/cjdk/_api.py
+++ b/src/cjdk/_api.py
@@ -9,19 +9,19 @@ from contextlib import contextmanager
 from . import _cache, _conf, _index, _install, _jdk
 
 __all__ = [
-    "list_vendors",
-    "list_jdks",
+    "cache_file",
     "cache_jdk",
+    "cache_package",
     "java_env",
     "java_home",
-    "cache_file",
-    "cache_package",
+    "list_jdks",
+    "list_vendors",
 ]
 
 
 def list_vendors(**kwargs):
     """
-    Output the list of available vendors.
+    Return the list of available JDK vendors.
 
     Parameters
     ----------
@@ -34,14 +34,15 @@ def list_vendors(**kwargs):
 
     Returns
     -------
-    None
+    list[str]
+        The available JDK vendors.
     """
-    print(os.linesep.join(sorted(_get_vendors(**kwargs))))
+    return sorted(_get_vendors(**kwargs))
 
 
 def list_jdks(*, vendor=None, version=None, cached_only=True, **kwargs):
     """
-    Output a list of JDKs matching the given criteria.
+    Return the list of JDKs matching the given criteria.
 
     Parameters
     ----------
@@ -69,12 +70,12 @@ def list_jdks(*, vendor=None, version=None, cached_only=True, **kwargs):
 
     Returns
     -------
-    None
+    list[str]
+        JDKs (vendor:version) matching the criteria.
     """
-    jdks_list = _get_jdks(
+    return _get_jdks(
         vendor=vendor, version=version, cached_only=cached_only, **kwargs
     )
-    print(os.linesep.join(jdks_list))
 
 
 def cache_jdk(*, vendor=None, version=None, **kwargs):

--- a/src/cjdk/_api.py
+++ b/src/cjdk/_api.py
@@ -77,13 +77,8 @@ def list_jdks(*, vendor=None, version=None, **kwargs):
     None
     """
     conf = _conf.configure(vendor=vendor, version=version, **kwargs)
-    # TODO: Eliminate code duplication with _index.resolve_jdk_version.
     jdks = _index.available_jdks(_index.jdk_index(conf), conf)
-    versions = [i[1] for i in jdks if i[0] == conf.vendor]
-    if not versions:
-        raise KeyError(
-            f"No {conf.vendor} JDK is available for {conf.os}-{conf.arch}"
-        )
+    versions = _index._get_versions(jdks, conf)
     matched = _index._match_versions(conf.vendor, versions, conf.version)
     print(f"[{conf.vendor}]")
     print(os.linesep.join([v for _, v in sorted(matched.items())]))

--- a/src/cjdk/_api.py
+++ b/src/cjdk/_api.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from contextlib import contextmanager
 
-from . import _cache, _conf, _install, _index, _jdk
+from . import _cache, _conf, _index, _install, _jdk
 
 __all__ = [
     "list_vendors",
@@ -42,7 +42,7 @@ def list_vendors(**kwargs):
         vendor.replace("jdk@", "")
         for osys in index
         for arch in index[osys]
-        for vendor in index[osys][arch].keys()
+        for vendor in index[osys][arch]
     }
     print(os.linesep.join(sorted(vendors)))
 
@@ -92,11 +92,8 @@ def list_jdks(*, vendor=None, version=None, cached_only=True, **kwargs):
             key = (_jdk._JDK_KEY_PREFIX, _cache._key_for_url(url))
             keydir = _cache._key_directory(conf.cache_dir, key)
             return keydir.exists()
-        matched = {
-            k: v
-            for k, v in matched.items()
-            if is_cached(v)
-        }
+
+        matched = {k: v for k, v in matched.items() if is_cached(v)}
 
     print(f"[{conf.vendor}]")
     print(os.linesep.join([v for _, v in sorted(matched.items())]))

--- a/src/cjdk/_api.py
+++ b/src/cjdk/_api.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from . import _conf, _install, _index, _jdk
 
 __all__ = [
+    "list_vendors",
     "list_jdks",
     "cache_jdk",
     "java_env",
@@ -16,6 +17,34 @@ __all__ = [
     "cache_file",
     "cache_package",
 ]
+
+
+def list_vendors(**kwargs):
+    """
+    Output the list of available vendors.
+
+    Parameters
+    ----------
+    None
+
+    Other Parameters
+    ----------------
+    index_url : str, optional
+        Alternative URL for the JDK index.
+
+    Returns
+    -------
+    None
+    """
+    conf = _conf.configure(**kwargs)
+    index = _index.jdk_index(conf)
+    vendors = {
+        vendor.replace("jdk@", "")
+        for osys in index
+        for arch in index[osys]
+        for vendor in index[osys][arch].keys()
+    }
+    print(os.linesep.join(sorted(vendors)))
 
 
 def list_jdks(*, vendor=None, version=None, **kwargs):

--- a/src/cjdk/_api.py
+++ b/src/cjdk/_api.py
@@ -302,7 +302,28 @@ def _get_jdks(*, vendor=None, version=None, cached_only=True, **kwargs):
 
         matched = {k: v for k, v in matched.items() if is_cached(v)}
 
-    return [f"{conf.vendor}:{v}" for k, v in sorted(matched.items())]
+    class VersionElement:
+        def __init__(self, value):
+            self.value = value
+            self.is_int = isinstance(value, int)
+
+        def __eq__(self, other):
+            if self.is_int and other.is_int:
+                return self.value == other.value
+            return str(self.value) == str(other.value)
+
+        def __lt__(self, other):
+            if self.is_int and other.is_int:
+                return self.value < other.value
+            return str(self.value) < str(other.value)
+
+    def version_key(version_tuple):
+        return tuple(VersionElement(elem) for elem in version_tuple[0])
+
+    return [
+        f"{conf.vendor}:{v}"
+        for k, v in sorted(matched.items(), key=version_key)
+    ]
 
 
 def _make_hash_checker(hashes):

--- a/src/cjdk/_cache.py
+++ b/src/cjdk/_cache.py
@@ -59,7 +59,7 @@ def atomic_file(
     ttl,
     timeout_for_fetch_elsewhere=10,
     timeout_for_read_elsewhere=2.5,
-):
+) -> Path:
     """
     Retrieve cached file for key, fetching with fetchfunc if necessary.
 
@@ -150,7 +150,7 @@ def permanent_directory(
     return keydir
 
 
-def _file_exists_and_is_fresh(file, ttl):
+def _file_exists_and_is_fresh(file, ttl) -> bool:
     if not file.is_file():
         return False
     now = time.time()
@@ -185,11 +185,11 @@ def _create_key_tmpdir(cache_dir, key):
                 shutil.rmtree(tmpdir)
 
 
-def _key_directory(cache_dir, key):
+def _key_directory(cache_dir: Path, key) -> Path:
     return cache_dir / "v0" / Path(*key)
 
 
-def _key_tmpdir(cache_dir, key):
+def _key_tmpdir(cache_dir: Path, key) -> Path:
     return cache_dir / "v0" / Path("fetching", *key)
 
 

--- a/src/cjdk/_conf.py
+++ b/src/cjdk/_conf.py
@@ -39,10 +39,15 @@ def configure(**kwargs):
             raise ValueError("Cannot specify jdk= together with version=")
         kwargs["vendor"], kwargs["version"] = _parse_vendor_version(jdk)
 
+    default_vendor = (
+        _default_vendor()
+        if kwargs.pop("fallback_to_default_vendor", True)
+        else None
+    )
     conf = Configuration(
         os=_canonicalize_os(kwargs.pop("os", None)),
         arch=_canonicalize_arch(kwargs.pop("arch", None)),
-        vendor=kwargs.pop("vendor", None) or _default_vendor(),
+        vendor=kwargs.pop("vendor", None) or default_vendor,
         version=kwargs.pop("version", "") or "",
         cache_dir=kwargs.pop("cache_dir", None) or _default_cachedir(),
         index_url=kwargs.pop("index_url", None) or _default_index_url(),

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -56,7 +56,7 @@ def resolve_jdk_version(index, conf: Configuration):
     Find in index the exact JDK version for the given configuration.
 
     Arguments:
-    index -- The JDK index (dested dict)
+    index -- The JDK index (nested dict)
     """
     jdks = available_jdks(index, conf)
     versions = [i[1] for i in jdks if i[0] == conf.vendor]

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -136,8 +136,14 @@ def _read_index(path: Path) -> Index:
     # unfortunately there is no way to know this from the index alone.
 
     pattern = re.compile("^(jdk@ibm-semeru.*)-java\\d+$")
+    if not hasattr(index, "items"):
+        return index
     for os, arches in index.items():
+        if not hasattr(arches, "items"):
+            continue
         for arch, vendors in arches.items():
+            if not hasattr(vendors, "items"):
+                continue
             for vendor, versions in vendors.copy().items():
                 if not vendor.startswith("jdk@graalvm") and (
                     m := pattern.match(vendor)

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -67,6 +67,10 @@ def resolve_jdk_version(index: Index, conf: Configuration) -> str:
     """
     jdks = available_jdks(index, conf)
     versions = _get_versions(jdks, conf)
+    if not versions:
+        raise KeyError(
+            f"No {conf.vendor} JDK is available for {conf.os}-{conf.arch}"
+        )
     return _match_version(conf.vendor, versions, conf.version)
 
 
@@ -152,12 +156,7 @@ def _postprocess_index(index: Index) -> Index:
 
 
 def _get_versions(jdks: tuple[str, str], conf) -> list[str]:
-    versions = [i[1] for i in jdks if i[0] == conf.vendor]
-    if not versions:
-        raise KeyError(
-            f"No {conf.vendor} JDK is available for {conf.os}-{conf.arch}"
-        )
-    return versions
+    return [i[1] for i in jdks if i[0] == conf.vendor]
 
 
 def _match_versions(

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -110,18 +110,25 @@ def _read_index(path: Path) -> Index:
     with open(path, encoding="ascii") as infile:
         index = json.load(infile)
 
-    # Post-process the index to normalize the data.
-    # Some "vendors" include the major Java version,
-    # so let's merge such entries. In particular:
-    #
-    # * ibm-semuru-openj9-java<##>
-    # * graalvm-java<##>
-    #
-    # However: while the graalvm vendors follow this pattern, the version
-    # numbers for graalvm are *not* JDK versions, but rather GraalVM versions,
-    # which merely strongly resemble JDK version strings. For example,
-    # graalvm-java17 version 22.3.3 bundles OpenJDK 17.0.8, but
-    # unfortunately there is no way to know this from the index alone.
+    return _postprocess_index(index)
+
+
+def _postprocess_index(index: Index) -> Index:
+    """
+    Post-process the index to normalize the data.
+
+    Some "vendors" include the major Java version,
+    so let's merge such entries. In particular:
+
+    * ibm-semuru-openj9-java<##>
+    * graalvm-java<##>
+
+    However: while the graalvm vendors follow this pattern, the version
+    numbers for graalvm are *not* JDK versions, but rather GraalVM versions,
+    which merely strongly resemble JDK version strings. For example,
+    graalvm-java17 version 22.3.3 bundles OpenJDK 17.0.8, but
+    unfortunately there is no way to know this from the index alone.
+    """
 
     pattern = re.compile("^(jdk@ibm-semeru.*)-java\\d+$")
     if not hasattr(index, "items"):

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -29,6 +29,18 @@ def jdk_index(conf: Configuration):
     return _read_index(_cached_index(conf))
 
 
+def available_vendors(index):
+    """
+    Find in index the available JDK vendors.
+
+    A set of strings is returned.
+
+    Arguments:
+    index -- The JDK index (nested dict)
+    """
+    return set(index[os][arch] for os in index for arch in index[os])
+
+
 def available_jdks(index, conf: Configuration):
     """
     Find in index the available JDK vendor-version combinations.

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -37,18 +37,6 @@ def jdk_index(conf: Configuration) -> Index:
     return _read_index(_cached_index_path(conf))
 
 
-def available_vendors(index: Index):
-    """
-    Find in index the available JDK vendors.
-
-    A set of strings is returned.
-
-    Arguments:
-    index -- The JDK index (nested dict)
-    """
-    return set(index[os][arch] for os in index for arch in index[os])
-
-
 def available_jdks(index: Index, conf: Configuration) -> tuple[str, str]:
     """
     Find in index the available JDK vendor-version combinations.

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -79,17 +79,8 @@ def resolve_jdk_version(index: Index, conf: Configuration):
     index -- The JDK index (nested dict)
     """
     jdks = available_jdks(index, conf)
-    versions = [i[1] for i in jdks if i[0] == conf.vendor]
-    if not versions:
-        raise KeyError(
-            f"No {conf.vendor} JDK is available for {conf.os}-{conf.arch}"
-        )
-    matched = _match_version(conf.vendor, versions, conf.version)
-    if not matched:
-        raise KeyError(
-            f"No JDK matching version {conf.version} for {conf.os}-{conf.arch}-{conf.vendor}"
-        )
-    return matched
+    versions = _get_versions(jdks, conf)
+    return _match_version(conf.vendor, versions, conf.version)
 
 
 def jdk_url(index: Index, conf: Configuration):
@@ -127,6 +118,15 @@ def _cached_index_path(conf: Configuration) -> Path:
 def _read_index(path: Path) -> Index:
     with open(path, encoding="ascii") as infile:
         return json.load(infile)
+
+
+def _get_versions(jdks: Tuple[str, str], conf) -> List[str]:
+    versions = [i[1] for i in jdks if i[0] == conf.vendor]
+    if not versions:
+        raise KeyError(
+            f"No {conf.vendor} JDK is available for {conf.os}-{conf.arch}"
+        )
+    return versions
 
 
 def _match_versions(vendor, candidates: List[str], requested):

--- a/src/cjdk/_index.py
+++ b/src/cjdk/_index.py
@@ -71,7 +71,7 @@ def available_jdks(index: Index, conf: Configuration) -> Tuple[str, str]:
     )
 
 
-def resolve_jdk_version(index: Index, conf: Configuration):
+def resolve_jdk_version(index: Index, conf: Configuration) -> str:
     """
     Find in index the exact JDK version for the given configuration.
 
@@ -83,7 +83,7 @@ def resolve_jdk_version(index: Index, conf: Configuration):
     return _match_version(conf.vendor, versions, conf.version)
 
 
-def jdk_url(index: Index, conf: Configuration):
+def jdk_url(index: Index, conf: Configuration, exact_version: str = None) -> str:
     """
     Find in index the URL for the JDK binary for the given vendor and version.
 
@@ -91,9 +91,11 @@ def jdk_url(index: Index, conf: Configuration):
 
     Arguments:
     index -- The JDK index (nested dict)
+    exact_version (optional) -- The JDK version, or None to resolve it from the configuration
     """
-    matched = resolve_jdk_version(index, conf)
-    return index[conf.os][conf.arch][f"jdk@{conf.vendor}"][matched]
+    if exact_version is None:
+        exact_version = resolve_jdk_version(index, conf)
+    return index[conf.os][conf.arch][f"jdk@{conf.vendor}"][exact_version]
 
 
 def _cached_index_path(conf: Configuration) -> Path:
@@ -129,7 +131,7 @@ def _get_versions(jdks: Tuple[str, str], conf) -> List[str]:
     return versions
 
 
-def _match_versions(vendor, candidates: List[str], requested):
+def _match_versions(vendor, candidates: List[str], requested) -> Dict[Tuple[int], str]:
     # Find all candidates compatible with the request
     is_graal = "graalvm" in vendor.lower()
     normreq = _normalize_version(requested, remove_prefix_1=not is_graal)
@@ -153,7 +155,7 @@ def _match_versions(vendor, candidates: List[str], requested):
     }
 
 
-def _match_version(vendor, candidates, requested):
+def _match_version(vendor, candidates: List[str], requested) -> str:
     matched = _match_versions(vendor, candidates, requested)
 
     if len(matched) == 0:

--- a/src/cjdk/_install.py
+++ b/src/cjdk/_install.py
@@ -4,6 +4,8 @@
 
 import sys
 
+from pathlib import Path
+
 from . import _cache, _download
 
 __all__ = [
@@ -12,7 +14,7 @@ __all__ = [
 ]
 
 
-def install_file(prefix, name, url, filename, conf, *, ttl, checkfunc=None):
+def install_file(prefix, name, url, filename, conf, *, ttl, checkfunc=None) -> Path:
     def fetch(dest):
         _print_progress_header(conf, name)
         _download.download_file(
@@ -33,7 +35,7 @@ def install_file(prefix, name, url, filename, conf, *, ttl, checkfunc=None):
     )
 
 
-def install_dir(prefix, name, url, conf, *, checkfunc=None):
+def install_dir(prefix, name, url, conf, *, checkfunc=None) -> Path:
     def fetch(destdir):
         _print_progress_header(conf, name)
         _download.download_and_extract(

--- a/src/cjdk/_install.py
+++ b/src/cjdk/_install.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import sys
-
 from pathlib import Path
 
 from . import _cache, _download
@@ -14,7 +13,9 @@ __all__ = [
 ]
 
 
-def install_file(prefix, name, url, filename, conf, *, ttl, checkfunc=None) -> Path:
+def install_file(
+    prefix, name, url, filename, conf, *, ttl, checkfunc=None
+) -> Path:
     def fetch(dest):
         _print_progress_header(conf, name)
         _download.download_file(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,3 +152,38 @@ def test_env_var_set():
     with f("CJDK_TEST_ENV_VAR", "testvalue"):
         assert os.environ["CJDK_TEST_ENV_VAR"] == "testvalue"
     assert "CJDK_TEST_ENV_VAR" not in os.environ
+
+
+def test_get_vendors():
+    vendors = _api._get_vendors()
+    assert vendors is not None
+    assert "adoptium" in vendors
+    assert "corretto" in vendors
+    assert "graalvm" in vendors
+    assert "ibm-semeru-openj9" in vendors
+    assert "java-oracle" in vendors
+    assert "liberica" in vendors
+    assert "temurin" in vendors
+    assert "zulu" in vendors
+
+
+def test_get_jdks():
+    jdks = _api._get_jdks(cached_only=False)
+    assert jdks is not None
+    assert "adoptium:1.21.0.4" in jdks
+    assert "corretto:21.0.4.7.1" in jdks
+    assert "graalvm-community:21.0.2" in jdks
+    assert "graalvm-java17:22.3.3" in jdks
+    assert "graalvm-java21:21.0.2" in jdks
+    assert "liberica:22.0.2" in jdks
+    assert "temurin:1.21.0.4" in jdks
+    assert "zulu:8.0.362" in jdks
+
+    cached_jdks = _api._get_jdks()
+    assert cached_jdks is not None
+    assert len(cached_jdks) < len(jdks)
+
+    zulu_jdks = _api._get_jdks(vendor="zulu", cached_only=False)
+    assert zulu_jdks is not None
+    assert len(set(zulu_jdks)) > 175
+    assert all(jdk.startswith("zulu:") for jdk in zulu_jdks)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -173,7 +173,6 @@ def test_get_jdks():
     assert "adoptium:1.21.0.4" in jdks
     assert "corretto:21.0.4.7.1" in jdks
     assert "graalvm-community:21.0.2" in jdks
-    assert "graalvm-java17:22.3.3" in jdks
     assert "graalvm-java21:21.0.2" in jdks
     assert "liberica:22.0.2" in jdks
     assert "temurin:1.21.0.4" in jdks
@@ -185,5 +184,5 @@ def test_get_jdks():
 
     zulu_jdks = _api._get_jdks(vendor="zulu", cached_only=False)
     assert zulu_jdks is not None
-    assert len(set(zulu_jdks)) > 175
+    assert len(set(zulu_jdks))
     assert all(jdk.startswith("zulu:") for jdk in zulu_jdks)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -30,6 +30,10 @@ def test_configure():
     assert conf.vendor == _conf._default_vendor()
     assert not conf.version
 
+    conf = f(jdk=":", fallback_to_default_vendor=False)
+    assert conf.vendor is None
+    assert not conf.version
+
     conf = f(cache_dir="abc")
     assert conf.cache_dir == Path("abc")
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -89,7 +89,7 @@ def test_jdk_url():
     )
 
 
-def test_cached_index(tmp_path):
+def test_cached_index_path(tmp_path):
     with mock_server.start(
         endpoint="/index.json", data={"hello": "world"}
     ) as server:
@@ -101,7 +101,7 @@ def test_cached_index(tmp_path):
             / _cache._key_for_url(url)
             / _index._INDEX_FILENAME
         )
-        path = _index._cached_index(
+        path = _index._cached_index_path(
             configure(
                 index_url=url,
                 cache_dir=tmp_path,
@@ -116,7 +116,7 @@ def test_cached_index(tmp_path):
 
         # Second time should return same data without fetching.
         assert server.request_count() == 1
-        path2 = _index._cached_index(
+        path2 = _index._cached_index_path(
             configure(
                 index_url=url,
                 cache_dir=tmp_path,

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -160,8 +160,8 @@ def test_normalize_version():
     assert f("1", remove_prefix_1=True) == ()
     assert f("1.8", remove_prefix_1=True) == (8,)
     assert f("1.8.0", remove_prefix_1=True) == (8, 0)
-    with pytest.raises(ValueError):
-        f("1.8u300", remove_prefix_1=True)
+    assert f("1.8u300", remove_prefix_1=True) == ("8u300",)
+    assert f("21.0.1+12_openj9-0.42.0") == (21, 0, 1, 12, "openj9", 0, 42, 0)
 
 
 def test_is_version_compatible_with_spec():


### PR DESCRIPTION
This patchset adds a command to list matching JDKs, and another to list available vendors.

I don't love it, so I dragged my feet before filing this PR, but the two new commands ostensibly work.

I already discussed these changes directly with @marktsuchida 1.5 years ago now... as a starting point for discussion, here is a transcript of that conversation:

@ctrueden wrote:

> Here are some questions and thoughts:
>
> * Would it be desirable to be able to filter more criteria (vendors, os, arch) more flexibly? E.g. match vendors via regex rather than just specifying the desired one? Or is this overkill? Maybe just globs, e.g. to match `zulu*` or even just `*`? Right now the `list-vendors` command I wrote just unions together all the vendors from all os/arch into one set...
> * Right now `cjdk list-jdks` lists all available jdks for the conf (e.g. `cjdk -j zulu:17+ list-jdks`). But I wanted to make `cjdk list-jdks --all` do that, and have `cjdk list-jdks` no-args only list the ones already cached. Or I guess `cjdk list-jdks --cached` could do that; either way. But I think both these modes are useful.
> * Would it make sense to have an `Index` class to provide an object-oriented of the index, instead of needing to pass the raw nested dict object around to all the `_index` functions? (asks the Java programmer :stuck_out_tongue_closed_eyes:)
> * Right now the `_api.list_jdks` function duplicates a little bit of code from `_index.resolve_jdk_version`, because the logic for filtering JDKs according to conf is not well-separated enough from the logic to resolve a single version. I split things up a little by making a `_match_versions` to return all whereas `_match_version` returns the best... but I didn't take it all the way. Would be good to think about an architectural adjustment to make filtering into its own standalone piece of the library.
>
> If you'd prefer I could file a draft PR and paste in these comments, whatever you like.
>
> You know what's really funny? I did this work as a rabbit hole so I could find out how to install Zulu JDK+FX with cjdk... and now that I've done it, and dug through the index, it looks like that version of the JDK isn't in there? Not that I can find, anyway. :joy:

@marktsuchida: We _could_ build our own index, or supplement it. Either by forking and extending the original one (it's Scala code) or upstreaming, or by making cjdk use multiple indexes.

@ctrueden: Supplementing the index would make sense to me... I'll see if anyone filed an issue in the Coursier repo.

@ctrueden: Heh, they don't have Issues. So yeah, either updating their code to include it, or making cjdk support unioning multiple indices. Eh, punting!

@marktsuchida wrote:

> Some not-so-organized thoughts/opinions on your comments above (I haven't yet looked at your patch in detail):
>
> * Globs maybe; regex seems overkill to me and harder to use for the majority of expected use cases (and people can/should pipe to `grep` if they really need to). Maybe limit to the vendor part, until we see a clear need for anything more.
>   * Examples: `*-jdk` (regular JDKs only), `graalvm-*` (GraalVM for any Java version), `zulu*-fx` (Zulu JRE or JDK but with OpenJFX; not currently available)
> * Is `*` the same as not giving a vendor? That seems natural when listing available JDKs, but the existing behavior is that empty vendor means `adoptium` (overridable). I think this suggests that matching expressions for listing are not necessarily the same concept as the JDK spec used by existing commands (as long as we preserve the current behavior for the latter).
> * If allowing globs also for the existing commands, we also need to define what happens when two JDKs match that differ only in vendor (my preference: print the ambiguous matches and fail).
> * I'm uncertain about allowing globs for OS and architecture. The main issue here is that there is already a pragmatic [transformation](https://github.com/cachedjdk/cjdk/blob/6f549d2f0a871bade0ecb4b837b2d29de1b08779/tests/test_conf.py#L106-L138) to map OSs and architectures to canonical names, and it's not clear how this would work in the presence of globbing.
> * The current `vendor:version` spec syntax was specifically designed to result in zero or one unambiguous matches in all cases (no unbreakable ties). The only natural way to extend this to the filtering use case (that I can think of) is to select, in addition to the primary match, the JDKs that "would have matched had there not been a newer version that also matches".
>   * Changing the meaning of the spec between commands doesn't seem like a very good idea.
>   * But this (again) leads to slightly counterintuitive results when combined with globbing: `17` will only list `adoptium` (JRE only); you would need `*:17` to list all vendors' Java 17 JREs and JDKs. (Though maybe that is not the end of the world.)
>
> `list-jdks`
>
> * Defaulting to showing only installed JDKs and providing a flag to list all available in the index sounds good to me.
>   * Maybe something more specific than `--all` (such as `--available`) would be good, because other criteria may come in to play later (such as whether or not to include system-installed JDKs that we detect)
> * I think I prefer `ls` over `list-jdks`, this being a command-line tool and this subcommand probably being one that will be frequently invoked
>   * In which case also `ls-vendors` instead of `list-vendors`
>   * Perhaps you were following the example of `cache-jdk` etc., but those are advanced or less frequently used subcommands
>   * Later there may also be added `ls-files` and `ls-packages`
>   * One could argue for renaming `cache-jdk` to just `cache` for consistency with `ls`
>   * The Python API function can be `list_jdks`
>
> Make `Index` a class?
>
> * I vaguely remember thinking about this but can't remember if there was any particular reason I decided against it.
> * Maybe the fact that it was hard to come up with a good set of primitive operations on it (it seemed necessary to either expose the internal structure or build all query logic into what I would like to be a pure-data object).
> * Still, giving it a name (so it can be used in type hints) may help with readability even if all internal data is exposed.
> * I don't know that binding functions with data is particularly necessary in Python, but I'm not opposed if it can be made to fit in well with the rest of the code and unit tests.
> * The other idea I had was to ingest all the data into an in-memory sqlite3 database and use proper queries on it. This might still make sense (and the db could even be cached on disk if it records the hash of the index from which it was created).

@ctrueden: Agreed about `ls` over `list-jdks`. This is also the command used by `pass` for example. (`git` uses `ls-files` but I just aliased it.)
