### PR TITLE
CI: Fix use of deprecated set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           VERSION="${GITHUB_REF##refs/tags/v}"
-          echo "::set-output name=version::${VERSION}"
+          echo "version=${VERSION}" >>$GITHUB_OUTPUT
       - name: Publish to gh-pages (tag)
         if: >-
           github.repository == 'cachedjdk/cjdk' &&


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/